### PR TITLE
Zipcode support in recall and market API endpoints

### DIFF
--- a/controllers/api/market.js
+++ b/controllers/api/market.js
@@ -14,4 +14,14 @@ module.exports = function(router) {
         });
     });
 
+    router.get('/:zipcode', function(req, res) {
+        UsdaMarketsApiService.getMarketsByZipcode(req.params.zipcode)
+        .then(function(result) {
+            res.json(result);
+        })
+        .catch(function(err) {
+            res.status(500).json({msg: err});
+        });
+    });
+
 };

--- a/controllers/api/recall.js
+++ b/controllers/api/recall.js
@@ -14,4 +14,14 @@ module.exports = function(router) {
         });
     });
 
+    router.get('/:zipcode', function(req, res) {
+        OpenFdaApiService.getRecallsByZipcode(req.params.zipcode, req.query.limit, req.query.skip)
+        .then(function(result) {
+            res.json(result);
+        })
+        .catch(function(err) {
+            res.status(500).json({msg: err});
+        });
+    });
+
 };

--- a/services/OpenFdaApiService.js
+++ b/services/OpenFdaApiService.js
@@ -3,9 +3,10 @@
 
 var promisedGet = require('../lib/promisedGet'),
     FccApiService = require('./FccApiService'),
+    ZippopotamusService = require('./ZippopotamusApiService'),
     Promise = require('bluebird');
 
-var getRecallsByFccStateDetails = function(stateDetails, limit, skip) {
+var getRecallsByStateDetails = function(stateDetails, limit, skip) {
     // Set some defaults
     limit = limit || 100;
     skip = skip || 0;
@@ -33,7 +34,23 @@ module.exports = {
         return FccApiService.getStateFromLatLong(lat, lon)
         .then(function(result) {
             if (result.code) {
-                return getRecallsByFccStateDetails(result, limit, skip);
+                return getRecallsByStateDetails(result, limit, skip);
+            } else {
+                return Promise.reject(rejection);
+            }
+        })
+        .catch(function(err) {
+            return Promise.reject(rejection);
+        });
+    },
+
+    getRecallsByZipcode: function(zipcode, limit, skip) {
+        var rejection = 'Invalid Zipcode';
+
+        return ZippopotamusService.getStateFromZipcode(zipcode)
+        .then(function(result) {
+            if (result.code) {
+                return getRecallsByStateDetails(result, limit, skip);
             } else {
                 return Promise.reject(rejection);
             }

--- a/services/UsdaMarketsApiService.js
+++ b/services/UsdaMarketsApiService.js
@@ -5,29 +5,40 @@ var _ = require('lodash'),
     Promise = require('bluebird'),
     promisedGet = require('../lib/promisedGet');
 
+var getMarketData = function(url, rejection) {
+    return promisedGet(url)
+    .then(function(response) {
+        if (response.results[0] && response.results[0].id === 'Error') {
+            return Promise.reject(rejection);
+        } else {
+            return {
+                results: _.map(response.results, function(result) {
+                    result.distance = result.marketname.split(' ', 1)[0].trim();
+                    result.marketname = result.marketname.replace(result.distance, '').trim();
+                    return result;
+                })
+            };
+        }
+    })
+    .catch(function(err) {
+        return Promise.reject(rejection);
+    });
+};
+
 module.exports = {
 
     getMarketsByLatLong: function(lat, lon) {
         var rejection = 'Invalid Latitude or Longitude';
-
         var url = 'http://search.ams.usda.gov/farmersmarkets/v1/data.svc/locSearch?lat=' + lat + '&lng=' + lon;
-        return promisedGet(url)
-        .then(function(response) {
-            if (response.results[0] && response.results[0].id === 'Error') {
-                return Promise.reject(rejection);
-            } else {
-                return {
-                    results: _.map(response.results, function(result) {
-                        result.distance = result.marketname.split(' ', 1)[0].trim();
-                        result.marketname = result.marketname.replace(result.distance, '').trim();
-                        return result;
-                    })
-                };
-            }
-        })
-        .catch(function(err) {
-            return Promise.reject(rejection);
-        });
+
+        return getMarketData(url, rejection);
+    },
+
+    getMarketsByZipcode: function(zipcode) {
+        var rejection = 'Invalid Zipcode';
+        var url = 'http://search.ams.usda.gov/farmersmarkets/v1/data.svc/zipSearch?zip=' + zipcode;
+
+        return getMarketData(url, rejection);
     }
 
 };

--- a/services/ZippopotamusApiService.js
+++ b/services/ZippopotamusApiService.js
@@ -1,0 +1,27 @@
+/* global -Promise */
+'use strict';
+
+var promisedGet = require('../lib/promisedGet');
+
+module.exports = {
+
+    getStateFromZipcode: function(zipcode) {
+        var url = 'http://api.zippopotam.us/us/' + zipcode;
+        var result = {
+            code: null,
+            name: null
+        };
+
+        return promisedGet(url)
+        .then(function(response) {
+            var place = response.places[0];
+            result.code = place['state abbreviation'];
+            result.name = place.state;
+            return result;
+        })
+        .catch(function(err) {
+            return result;
+        });
+    }
+
+};

--- a/test/data/zippopotamus-24153.json
+++ b/test/data/zippopotamus-24153.json
@@ -1,0 +1,1 @@
+{"post code": "24153", "country": "United States", "country abbreviation": "US", "places": [{"place name": "Salem", "longitude": "-80.0692", "state": "Virginia", "state abbreviation": "VA", "latitude": "37.2853"}]}

--- a/test/spec/server/controllers/api/marketSpec.js
+++ b/test/spec/server/controllers/api/marketSpec.js
@@ -6,6 +6,55 @@ var marketsDataVA = require('../../../../data/markets-va.json'),
     marketsDataEmpty = require('../../../../data/markets-no-matches.json'),
     marketsDataError = require('../../../../data/markets-error.json');
 
+describe('/api/market/:zipcode', function() {
+
+    beforeEach(function() {
+        nock.cleanAll();
+    });
+
+    it('should return data when passed a valid zipcode', function(done) {
+
+        nock('http://search.ams.usda.gov/')
+        .get('/farmersmarkets/v1/data.svc/zipSearch?zip=24153')
+        .reply(200, marketsDataVA);
+
+        request(mock)
+            .get('/api/market/24153')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .expect(/"distance"/)
+            .end(function(err, res) {
+                done(err);
+            });
+    });
+
+    it('should return 500 when passed an invalid zipcode', function(done) {
+
+        nock('http://search.ams.usda.gov/')
+        .get('/farmersmarkets/v1/data.svc/zipSearch?zip=2415')
+        .reply(200, marketsDataError);
+
+        request(mock)
+            .get('/api/market/2415')
+            .expect(500)
+            .expect('Content-Type', /json/)
+            .expect(/"msg"/)
+            .end(function(err, res) {
+                done(err);
+            });
+    });
+
+    it('should return 404 due to too little parameters in path', function(done) {
+        request(mock)
+            .get('/api/market/')
+            .expect(404)
+            .end(function(err, res) {
+                done(err);
+            });
+    });
+
+});
+
 describe('/api/market/:lat/:lon', function() {
 
     beforeEach(function() {
@@ -63,15 +112,6 @@ describe('/api/market/:lat/:lon', function() {
     it('should return 404 due to too many parameters in path', function(done) {
         request(mock)
             .get('/api/market/37.2869/-80.0558/0')
-            .expect(404)
-            .end(function(err, res) {
-                done(err);
-            });
-    });
-
-    it('should return 404 due to too little parameters in path', function(done) {
-        request(mock)
-            .get('/api/market/37.2869')
             .expect(404)
             .end(function(err, res) {
                 done(err);

--- a/test/spec/server/controllers/api/recallSpec.js
+++ b/test/spec/server/controllers/api/recallSpec.js
@@ -13,6 +13,26 @@ describe('/api/recall/:zipcode', function() {
         nock.cleanAll();
     });
 
+    it('should return data when passed a valid zip', function(done) {
+
+        nock('http://api.zippopotam.us')
+        .get('/us/24153')
+        .reply(200, zipVA);
+
+        nock('https://api.fda.gov')
+        .get('/food/enforcement.json?limit=100&skip=0&search=status%3A%22Ongoing%22%20AND%20(distribution_pattern%3A%22nationwide%22%20distribution_pattern%3A%22VA%22)')
+        .reply(200, recallDataVA);
+
+        request(mock)
+            .get('/api/recall/24153')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .expect(/"last_updated"/)
+            .end(function(err, res) {
+                done(err);
+            });
+    });
+
     it('should return 500 when passed an invalid zipcode', function(done) {
         nock('http://api.zippopotam.us/')
         .get('/us/2415')

--- a/test/spec/server/controllers/api/recallSpec.js
+++ b/test/spec/server/controllers/api/recallSpec.js
@@ -3,8 +3,41 @@
 'use strict';
 
 var latLonVA = require('../../../../data/fcc-lat-lon-va.json');
+var zipVA = require('../../../../data/zippopotamus-24153.json');
 var latLonNull = require('../../../../data/fcc-lat-lon-null.json');
 var recallDataVA = require('../../../../data/food-recalls-va.json');
+
+describe('/api/recall/:zipcode', function() {
+
+    beforeEach(function() {
+        nock.cleanAll();
+    });
+
+    it('should return 500 when passed an invalid zipcode', function(done) {
+        nock('http://api.zippopotam.us/')
+        .get('/us/2415')
+        .reply(404, {});
+
+        request(mock)
+            .get('/api/recall/2415')
+            .expect(500)
+            .expect('Content-Type', /json/)
+            .expect(/"msg"/)
+            .end(function(err, res) {
+                done(err);
+            });
+    });
+
+    it('should return 404 due to too little parameters in path', function(done) {
+        request(mock)
+            .get('/api/recall')
+            .expect(404)
+            .end(function(err, res) {
+                done(err);
+            });
+    });
+
+});
 
 describe('/api/recall/:lat/:lon', function() {
 
@@ -127,15 +160,6 @@ describe('/api/recall/:lat/:lon', function() {
     it('should return 404 due to too many parameters in path', function(done) {
         request(mock)
             .get('/api/recall/37/-80/0')
-            .expect(404)
-            .end(function(err, res) {
-                done(err);
-            });
-    });
-
-    it('should return 404 due to too little parameters in path', function(done) {
-        request(mock)
-            .get('/api/recall/37')
             .expect(404)
             .end(function(err, res) {
                 done(err);

--- a/test/spec/server/services/UsdaMarketsApiServiceSpec.js
+++ b/test/spec/server/services/UsdaMarketsApiServiceSpec.js
@@ -28,6 +28,25 @@ describe('USDA Farmers Markets Api Service', function() {
 
     });
 
+    it('should return data in correct format when proper zip is used', function(done) {
+
+        expect(marketsDataVA.results[0]).to.not.have.property('distance');
+
+        nock('http://search.ams.usda.gov/')
+        .get('/farmersmarkets/v1/data.svc/zipSearch?zip=24153')
+        .reply(200, marketsDataVA);
+
+        UsdaMarketsApiService.getMarketsByZipcode('24153')
+        .then(function(result) {
+            expect(result).to.have.property('results');
+            expect(result.results.length).to.be(19);
+            expect(result.results[0]).to.have.property('distance');
+            expect(result.results[0].distance).to.be('0.4');
+            done();
+        });
+
+    });
+
     it('should return empty result set when invalid lat/long is used', function(done) {
 
         nock('http://search.ams.usda.gov/')
@@ -67,6 +86,20 @@ describe('USDA Farmers Markets Api Service', function() {
         .catch(function(err) {
             expect(err).to.not.be(null);
             expect(err).to.be('Invalid Latitude or Longitude');
+            done();
+        });
+    });
+
+    it('should reject when we do not have a valid zipcode', function(done) {
+
+        nock('http://search.ams.usda.gov/')
+        .get('/farmersmarkets/v1/data.svc/zipSearch?zip=2415')
+        .reply(200, marketsDataError);
+
+        UsdaMarketsApiService.getMarketsByZipcode('2415')
+        .catch(function(err) {
+            expect(err).to.not.be(null);
+            expect(err).to.be('Invalid Zipcode');
             done();
         });
     });

--- a/test/spec/server/services/ZippopotamusApiServiceSpec.js
+++ b/test/spec/server/services/ZippopotamusApiServiceSpec.js
@@ -1,0 +1,40 @@
+/*global describe:false, it:false, beforeEach:false, afterEach:false, request:false, mock:false, nock:false*/
+
+'use strict';
+
+var ZippopotamusApiService = require('../../../../services/ZippopotamusApiService');
+
+describe('Zippopotamus Api Service', function() {
+
+    it('should return "State" block with valid info when proper zip is used', function(done) {
+
+        nock('http://api.zippopotam.us')
+        .get('/us/24153')
+        .reply(200, require('../../../data/zippopotamus-24153.json'));
+
+        ZippopotamusApiService.getStateFromZipcode('24153')
+        .then(function(result) {
+            expect(result).to.not.have.property('status');
+            expect(result).to.have.property('code');
+            expect(result.code).to.be('VA');
+            done();
+        });
+
+    });
+
+    it('should return "State" block with null info when zip does not exist or is invalid', function(done) {
+
+        nock('http://api.zippopotam.us/')
+        .get('/us/2415')
+        .reply(404, {});
+
+        ZippopotamusApiService.getStateFromZipcode('2415')
+        .then(function(result) {
+            expect(result).to.not.have.property('status');
+            expect(result).to.have.property('code');
+            expect(result.code).to.be(null);
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
For #7 

Make sure that we support `/api/recall/:zipcode` and `/api/market/:zipcode`