### PR TITLE
Fix sass workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ node_modules
 
 docs/*
 
+.tmp/
 public/bundle
 
 # Ignore the compiled CSS files

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function(grunt) {
             'jscs',
             'jshint',
             'browserify:dev',
-            'sass',
+            'sass:serve',
             'concurrent:local',
             'autoprefixer',
             'develop',

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -9,6 +9,11 @@ module.exports = function sass(grunt) {
         options: {
             sourceMap: true
         },
+        serve: {
+            files: {
+                'public/styles/main.css': 'public/styles/main.scss'
+            }
+        },
         dist: {
             sourceMap: false,
             files: {

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -5,6 +5,9 @@ module.exports = function watch(grunt) {
     grunt.loadNpmTasks('grunt-contrib-watch');
 
     return {
+        options: {
+            livereload: true
+        },
         server: {
             files: [
                 'index.js',
@@ -15,19 +18,23 @@ module.exports = function watch(grunt) {
             ],
             tasks: ['jscs:all', 'jshint', 'develop'],
             options: {
+                livereload: false,
                 spawn: false
             }
         },
-        client: {
+        sass: {
+            files: ['public/styles/**/*.scss'],
+            tasks: ['sass:serve', 'copy:styles']
+        },
+        js: {
+            files: ['public/scripts/**/*.js'],
+            tasks: ['jscs:all', 'jshint', 'browserify:dev']
+        },
+        livereload: {
             files: [
-                'public/**/*',
-                '!public/bundle/*.js'
-            ],
-            tasks: ['jscs:all', 'jshint', 'browserify:dev'],
-            options: {
-                livereload: true
-            }
+              'public/**/*.html',
+              'public/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+            ]
         }
     };
-
 };


### PR DESCRIPTION
Cleanup the `grunt serve` workflow to make it easier to test sass changes when working locally.